### PR TITLE
show service disabled message if innactive

### DIFF
--- a/src/views/Service/Service.tsx
+++ b/src/views/Service/Service.tsx
@@ -45,6 +45,7 @@ import { UsefulInfoCardAccordian, UsefulInfoCard } from './UsefulInfoCard';
 import RelatedServices from './RelatedServices';
 import Breadcrumb from '../../components/Breadcrumb';
 import Loading from '../../components/Loading';
+import ServiceDisabled from './ServiceDisabled';
 
 interface RouteParams {
   service: string;
@@ -91,6 +92,11 @@ class Service extends Component<IProps> {
     const { service, locations, relatedServices } = serviceStore;
     if (!service) {
       return null;
+    }
+
+    // service is disabled
+    if (service.status === 'inactive') {
+      return <ServiceDisabled />;
     }
 
     return (

--- a/src/views/Service/ServiceDisabled.tsx
+++ b/src/views/Service/ServiceDisabled.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const ServiceDisabled = () => (
+  <div className="flex-container flex-container--align-center not__found ">
+    <div className="flex-col flex-col--12">
+      <h1 className="not__found--heading">Service not available</h1>
+      <p className="body-l">
+        This service has been removed from Connected Kingston. Please contact{' '}
+        <a href="mailto:info@connectedkingston.uk">info@connectedkingston.uk</a> for more
+        information.
+      </p>
+    </div>
+  </div>
+);
+
+export default ServiceDisabled;


### PR DESCRIPTION
If service returns status of innactive, display a message rather than the details.

![image](https://user-images.githubusercontent.com/27202958/81929144-62bc3000-95de-11ea-9eb9-8bd77796f6c7.png)
